### PR TITLE
Bugfix: Handle missing userRole for chargers

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -225,7 +225,7 @@ class Charger(BaseDict):
         self.name: str = entries["name"]
         self.product_code: int = entries["productCode"]
         self.level_of_access: int = entries["levelOfAccess"]
-        self.user_role: int = entries["userRole"]
+        self.user_role: int = entries.get("userRole", -1)
         self.site = site
         self.circuit = circuit
         self.easee = easee


### PR DESCRIPTION
Easee.get_chargers API call does not return userRole (at least on my user). This code will set userRole to -1 if missing in API-call.