### PR TITLE
Add poll energy and opmode to charger

### DIFF
--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -585,3 +585,17 @@ class Charger(BaseDict):
             return await self.easee.delete(f"/api/chargers/{self.id}/access")
         except (ServerFailureException):
             return None
+
+    async def poll_lifetimeenergy(self):
+        """Polls for a new Energy Reading from the charger. Warning: Rate limited to once every 3 minutes."""
+        try:
+            return await self.easee.post(f"/api/chargers/{self.id}/commands/poll_lifetimeenergy")
+        except (ServerFailureException):
+            return None
+
+    async def poll_chargeropmode(self):
+        """Polls for a new Charger Op Mode from the charger. Warning: Rate limited to once every 3 minutes."""
+        try:
+            return await self.easee.post(f"/api/chargers/{self.id}/commands/poll_chargeropmode")
+        except (ServerFailureException):
+            return None

--- a/pyeasee/charger.py
+++ b/pyeasee/charger.py
@@ -586,14 +586,14 @@ class Charger(BaseDict):
         except (ServerFailureException):
             return None
 
-    async def poll_lifetimeenergy(self):
+    async def force_update_lifetimeenergy(self):
         """Polls for a new Energy Reading from the charger. Warning: Rate limited to once every 3 minutes."""
         try:
             return await self.easee.post(f"/api/chargers/{self.id}/commands/poll_lifetimeenergy")
         except (ServerFailureException):
             return None
 
-    async def poll_chargeropmode(self):
+    async def force_update_chargeropmode(self):
         """Polls for a new Charger Op Mode from the charger. Warning: Rate limited to once every 3 minutes."""
         try:
             return await self.easee.post(f"/api/chargers/{self.id}/commands/poll_chargeropmode")


### PR DESCRIPTION
poll_lifetimeenergy and poll_chargeropmode is available in the API but was not implemented in the client.