### PR TITLE
Replace signalr lib with pysignalr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     ],
     packages=["pyeasee"],
     include_package_data=True,
-    install_requires=["aiohttp", "signalrcore==0.9.5"],
+    install_requires=["aiohttp", "pysignalr>=1.0.0"],
     entry_points={"console_scripts": ["pyeasee=pyeasee.__main__:main"]},
 )


### PR DESCRIPTION
The lib used for signalr up until now (signalrcore) is outdated and is causing dependancy problems with other custom modules. This PR replaces it with pysignalr. 