### PR TITLE
SignalR lib reconnect issue workaround

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -255,7 +255,7 @@ class Easee:
 
         self.sr_connect_in_progress = False
         self.sr_connected = False
-        await self._sr_connect(SR_INC_BACKOFF)
+        await self._sr_connect(self._sr_next())
 
     async def _sr_error_cb(self, message: CompletionMessage) -> None:
         _LOGGER.debug("SignalR error recevied {message.error}")

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -245,7 +245,10 @@ class Easee:
         """
         Signalr disconnected callback - called from signalr thread, internal use only
         """
-        _LOGGER.debug("SignalR stream disconnected")
+        _LOGGER.debug("SignalR stream disconnected or failed to connect")
+        if self._sr_task is not None:
+            self._sr_task.cancel()
+        self.sr_connect_in_progress = False
         self.sr_connected = False
         await self._sr_connect(SR_INC_BACKOFF)
 

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -248,6 +248,11 @@ class Easee:
         _LOGGER.debug("SignalR stream disconnected or failed to connect")
         if self._sr_task is not None:
             self._sr_task.cancel()
+            try:
+                await self._sr_task
+            except asyncio.CancelledError:
+                _LOGGER.debug("SignalR task cancelled")
+
         self.sr_connect_in_progress = False
         self.sr_connected = False
         await self._sr_connect(SR_INC_BACKOFF)


### PR DESCRIPTION
The signalr lib seems to retry in an endless loop when it fails to negotiate the initial connection.
It does however seem to change the status from connecting to disconnected when this happens so we should get a callback.
This patch tries to work around that by cancelling the signalr task when that happens, and then restart it after a delay.