### PR TITLE
Add throttler context to requests

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -137,7 +137,7 @@ class Easee:
         self._sr_backoff = SR_MIN_BACKOFF
         self._sr_task = None
 
-        self.throttler = Throttler(rate_limit=20, period=10.0, retry_interval=0.5)
+        self.throttler = Throttler(rate_limit=15, period=9.0, retry_interval=1.0)
 
         # Override the __aiter__ method of the pysignalr.websocket Connect class
         pysignalr.websockets.legacy.client.Connect.__aiter__ = __aiter__  # type: ignore[method-assign]

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -5,7 +5,9 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 import ssl
-from typing import Any, AsyncIterator, Dict, List
+import time
+from collections import deque
+from typing import Any, AsyncIterator, Deque, Dict, List
 
 import aiohttp
 import pysignalr
@@ -135,6 +137,8 @@ class Easee:
         self._sr_backoff = SR_MIN_BACKOFF
         self._sr_task = None
 
+        self.throttler = Throttler(rate_limit=20, period=10.0, retry_interval=0.5)
+
         # Override the __aiter__ method of the pysignalr.websocket Connect class
         pysignalr.websockets.legacy.client.Connect.__aiter__ = __aiter__  # type: ignore[method-assign]
 
@@ -144,28 +148,32 @@ class Easee:
     async def post(self, url, **kwargs):
         _LOGGER.debug("POST: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.post(f"{self.base}{url}", headers=self.headers, **kwargs)
+        async with self.throttler:
+            response = await self.session.post(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
     async def put(self, url, **kwargs):
         _LOGGER.debug("PUT: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.put(f"{self.base}{url}", headers=self.headers, **kwargs)
+        async with self.throttler:
+            response = await self.session.put(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
     async def get(self, url, **kwargs):
         _LOGGER.debug("GET: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.get(f"{self.base}{url}", headers=self.headers, **kwargs)
+        async with self.throttler:
+            response = await self.session.get(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
     async def delete(self, url, **kwargs):
         _LOGGER.debug("DELETE: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        response = await self.session.delete(f"{self.base}{url}", headers=self.headers, **kwargs)
+        async with self.throttler:
+            response = await self.session.delete(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
 
@@ -460,3 +468,35 @@ class Easee:
             return records
         except (ServerFailureException):
             return None
+
+class Throttler:
+    def __init__(self, rate_limit: int, period=1.0, retry_interval=0.01):
+        self.rate_limit = rate_limit
+        self.period = period
+        self.retry_interval = retry_interval
+
+        self._task_logs: Deque[float] = deque()
+
+    def flush(self):
+        now = time.monotonic()
+        while self._task_logs:
+            if now - self._task_logs[0] > self.period:
+                self._task_logs.popleft()
+            else:
+                break
+
+    async def acquire(self):
+        while True:
+            self.flush()
+            if len(self._task_logs) < self.rate_limit:
+                break
+            _LOGGER.debug("Delay due to throttling")
+            await asyncio.sleep(self.retry_interval)
+
+        self._task_logs.append(time.monotonic())
+
+    async def __aenter__(self):
+        await self.acquire()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass


### PR DESCRIPTION
WIP:
Add throttler context to requests. The limits are set when initiating the Easee class.

No 429 handler yet.