### PR TITLE
Fix refresh token crash and Python 3.9 compatibility

### DIFF
--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -234,6 +234,7 @@ class Easee:
             res = await self.session.post(
                 f"{self.base}/api/accounts/refresh_token", headers=self.minimal_headers, json=data
             )
+            await raise_for_status(res)
             await self._handle_token_response(res)
         except (AuthorizationFailedException, BadRequestException):
             _LOGGER.debug("Could not get new access token from refresh token, getting new one")

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 import ssl
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 import aiohttp
 import pysignalr
@@ -94,9 +94,9 @@ class Easee:
         self,
         username,
         password,
-        session: aiohttp.ClientSession | None = None,
+        session: Optional[aiohttp.ClientSession] = None,
         user_agent=None,
-        ssl: ssl.SSLContext | None = None,
+        ssl: Optional[ssl.SSLContext] = None,
     ):
         self.username = username
         self.password = password


### PR DESCRIPTION
This fixes the following things:
* The `_refresh_token()` call did not appropriately check for return http status, sometimes resulting in an invalid token being returned and used elsewhere (causing crashes)
* The `|` type operator caused the code to be incompatible with Python 3.9