### PR TITLE
Throttling and 429.

### DIFF
--- a/pyeasee/__init__.py
+++ b/pyeasee/__init__.py
@@ -6,4 +6,5 @@ from .const import *  # noqa:
 from .easee import *  # noqa:
 from .easee import __VERSION__ as __version__  # noqa:
 from .site import *  # noqa:
+from .throttler import *  # noqa:
 from .utils import *  # noqa:

--- a/pyeasee/easee.py
+++ b/pyeasee/easee.py
@@ -2,12 +2,10 @@
 Main client for the Eesee account.
 """
 import asyncio
-from collections import deque
 from datetime import datetime, timedelta
 import logging
 import ssl
-import time
-from typing import Any, AsyncIterator, Deque, Dict, List
+from typing import Any, AsyncIterator, Dict, List
 
 import aiohttp
 import pysignalr
@@ -26,6 +24,7 @@ from .exceptions import (
     TooManyRequestsException,
 )
 from .site import Site, SiteState
+from .throttler import Throttler
 from .utils import convert_stream_data
 
 __VERSION__ = "0.8.13"
@@ -67,7 +66,7 @@ async def raise_for_status(response):
             raise NotFoundException(data)
         elif 429 == response.status:
             _LOGGER.debug("Too many requests " + f"({response.status}: {data} {response.url})")
-            raise TooManyRequestsException(data)
+            raise TooManyRequestsException(data, response.headers.get("retry-after"))
         elif response.status >= 500:
             _LOGGER.warning("Server failure" + f"({response.status}: {response.url})")
             raise ServerFailureException(data)
@@ -137,7 +136,8 @@ class Easee:
         self._sr_backoff = SR_MIN_BACKOFF
         self._sr_task = None
 
-        self.throttler = Throttler(rate_limit=15, period=9.0, retry_interval=1.0)
+        self._general_throttler = Throttler(rate_limit=500, period=300, name="general")
+        self._sites_throttler = Throttler(rate_limit=10, period=3600, name="sites")
 
         # Override the __aiter__ method of the pysignalr.websocket Connect class
         pysignalr.websockets.legacy.client.Connect.__aiter__ = __aiter__  # type: ignore[method-assign]
@@ -148,7 +148,7 @@ class Easee:
     async def post(self, url, **kwargs):
         _LOGGER.debug("POST: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        async with self.throttler:
+        async with self._general_throttler:
             response = await self.session.post(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
@@ -156,7 +156,7 @@ class Easee:
     async def put(self, url, **kwargs):
         _LOGGER.debug("PUT: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        async with self.throttler:
+        async with self._general_throttler:
             response = await self.session.put(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
@@ -164,7 +164,7 @@ class Easee:
     async def get(self, url, **kwargs):
         _LOGGER.debug("GET: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        async with self.throttler:
+        async with self._general_throttler:
             response = await self.session.get(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
@@ -172,7 +172,7 @@ class Easee:
     async def delete(self, url, **kwargs):
         _LOGGER.debug("DELETE: %s (%s)", url, kwargs)
         await self._verify_updated_token()
-        async with self.throttler:
+        async with self._general_throttler:
             response = await self.session.delete(f"{self.base}{url}", headers=self.headers, **kwargs)
         await self.check_status(response)
         return response
@@ -412,7 +412,8 @@ class Easee:
     async def get_site(self, id: int) -> Site:
         """get site by id"""
         try:
-            data = await (await self.get(f"/api/sites/{id}?detailed=true")).json()
+            async with self._sites_throttler:
+                data = await (await self.get(f"/api/sites/{id}?detailed=true")).json()
             _LOGGER.debug("Site:  %s", data)
             return Site(data, self)
         except (ServerFailureException):
@@ -468,36 +469,3 @@ class Easee:
             return records
         except (ServerFailureException):
             return None
-
-
-class Throttler:
-    def __init__(self, rate_limit: int, period=1.0, retry_interval=0.01):
-        self.rate_limit = rate_limit
-        self.period = period
-        self.retry_interval = retry_interval
-
-        self._task_logs: Deque[float] = deque()
-
-    def flush(self):
-        now = time.monotonic()
-        while self._task_logs:
-            if now - self._task_logs[0] > self.period:
-                self._task_logs.popleft()
-            else:
-                break
-
-    async def acquire(self):
-        while True:
-            self.flush()
-            if len(self._task_logs) < self.rate_limit:
-                break
-            _LOGGER.debug("Delay due to throttling")
-            await asyncio.sleep(self.retry_interval)
-
-        self._task_logs.append(time.monotonic())
-
-    async def __aenter__(self):
-        await self.acquire()
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass

--- a/pyeasee/throttler.py
+++ b/pyeasee/throttler.py
@@ -1,0 +1,47 @@
+"""
+Main client for the Eesee account.
+"""
+import asyncio
+from collections import deque
+import logging
+import time
+from typing import Deque
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Throttler:
+    def __init__(self, rate_limit: int, period: float = 1.0, name: str = ""):
+        self.rate_limit = rate_limit
+        self.period = period
+        self.name = name
+
+        self._task_logs: Deque[float] = deque()
+
+    def flush(self):
+        now = time.monotonic()
+        while self._task_logs:
+            if now - self._task_logs[0] > self.period:
+                self._task_logs.popleft()
+            else:
+                break
+
+    async def acquire(self):
+        self.flush()
+        if len(self._task_logs) >= self.rate_limit:
+            _LOGGER.debug(
+                "Delay %f seconds due to throttling (%d calls per %f seconds allowed for %s).",
+                self.period / self.rate_limit,
+                self.rate_limit,
+                self.period,
+                self.name,
+            )
+            await asyncio.sleep(self.period / self.rate_limit)
+
+        self._task_logs.append(time.monotonic())
+
+    async def __aenter__(self):
+        await self.acquire()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass

--- a/pyeasee/throttler.py
+++ b/pyeasee/throttler.py
@@ -1,5 +1,5 @@
 """
-Main client for the Eesee account.
+Throttler for API calls
 """
 import asyncio
 from collections import deque


### PR DESCRIPTION
Enforce throttling on specific APIs. 
Add retry-after argument to 429 exception.
Move throttler to separate file.
Improved throttling mechanism matching Easee API retry-after times.